### PR TITLE
修改ScrewDriver的行為

### DIFF
--- a/include/Component/ScrewDriver.hpp
+++ b/include/Component/ScrewDriver.hpp
@@ -25,7 +25,7 @@ private:
     std::vector<std::shared_ptr<Ammo>> Magazine;
 
     // Deal Animation of ScrewDriver.
-    float AnimationTimer = 0, AnimationInterval = 60;
+    float AnimationTimer = 0, AnimationInterval = 80;
     int AnimationCount = 0;
     bool Open = 0, StartUp = 0;
     int PathIndex = 0;

--- a/include/Component/ScrewDriver.hpp
+++ b/include/Component/ScrewDriver.hpp
@@ -25,7 +25,7 @@ private:
     std::vector<std::shared_ptr<Ammo>> Magazine;
 
     // Deal Animation of ScrewDriver.
-    float AnimationTimer = 0, AnimationInterval = 80;
+    float AnimationTimer = 0, AnimationInterval = 60;
     int AnimationCount = 0;
     bool Open = 0, StartUp = 0;
     int PathIndex = 0;

--- a/src/Component/ScrewDriver.cpp
+++ b/src/Component/ScrewDriver.cpp
@@ -20,13 +20,15 @@ void Screwdriver::DoBehavior(glm::vec2 CameraPos,glm::vec2 RockmanPos,int SceneS
         StartUp = true;
     if (StartUp) {
         if (Open) {
+            Hitbox = std::make_shared<Collider>(Position,glm::vec2 {16*3,16*3},glm::vec2 {0,0});
+            Hurt = HurtState::COWARDLY;
             if (Util::Time::GetElapsedTimeMs() - AnimationTimer >
                 AnimationInterval) {
                 PathIndex = PathIndex + 1;
                 if (PathIndex >= 5)
                     PathIndex = 2;
                 AnimationCount++;
-                if (AnimationCount == 7 || AnimationCount == 13) {
+                if (AnimationCount == 13) {
                     Shoot();
                 }
                 if (AnimationCount > 15) {
@@ -37,7 +39,9 @@ void Screwdriver::DoBehavior(glm::vec2 CameraPos,glm::vec2 RockmanPos,int SceneS
                 AnimationTimer = Util::Time::GetElapsedTimeMs();
             }
         }
-        else if (!Open) {
+        else{
+            Hitbox = std::make_shared<Collider>(Position,glm::vec2 {16*3,8*3},glm::vec2 {0,-24});
+            Hurt = HurtState::INVINCIBLE;
             if (Util::Time::GetElapsedTimeMs() - AnimationTimer >
                 AnimationInterval) {
                 if (PathIndex > 0)
@@ -88,4 +92,5 @@ void Screwdriver::Reset() {
     Object->SetVisible(Visable);
     Object->SetImage(ObjectPath[0]);
 }
+
 

--- a/src/PhaseStage.cpp
+++ b/src/PhaseStage.cpp
@@ -142,9 +142,9 @@ void PhaseStage::Init(App *app) {
     for (int i = 0; i < 3; i++) {
         std::shared_ptr<Screwdriver> screwdriver =
             std::make_shared<Screwdriver>(
-                glm::vec2{4295 + 301.5 * i, -3602}, glm::vec2{3, 3},
-                glm::vec2{16 * 3, 16 * 3}, ScrewDriverPath, ScrewDriverAmmoPath,
-                Enemy::LifeState::LIFE, Enemy::HurtState::COWARDLY, 1, true);
+                glm::vec2{4295 + 301.5 * i, -3600}, glm::vec2{3, 3},
+                glm::vec2{16 * 3, 8 * 3}, ScrewDriverPath, ScrewDriverAmmoPath,
+                Enemy::LifeState::LIFE, Enemy::HurtState::INVINCIBLE, 6, true);
         m_Screwdriver.push_back(screwdriver);
         m_Enemies.push_back(screwdriver);
         app->GetRoot()->AddChild(screwdriver->GetChild());


### PR DESCRIPTION
由於ScrewDriver可能會射太多子彈
故調整ScrewDriver的行為
內容如下

- 修改射擊次數，僅在啟動後射擊一次
- 增加兩種不同狀態下的碰撞箱
- 由於原版的ScrewDriver需要射擊較多次才可以死亡，故調整血量上限
